### PR TITLE
Fix index offset being incorrect if element is coming from outside

### DIFF
--- a/src/sortable.coffee
+++ b/src/sortable.coffee
@@ -69,7 +69,8 @@ class Sortable extends DragAndDrop
       # so placeholder will be off by elements.length when being dragged
       # "down" beneath the elements.
       if @options.manual && _index > data.originalIndex.start
-        _index -= $elements.length
+        for element in $elements when @el.contains(element)
+          _index -= 1
 
       # If were moving the elements "up", then the placeholder would be above where the
       # elements came from, so we'll need to -1 from the originalIndex indices.


### PR DESCRIPTION
https://github.com/flowapp/droppable.js/commit/63a481f2adf10051619538a098327a647c53c472

Fixed a problem with index being too large when `options.manual` was true in
sortable. However, it didn't take into account the possibility that the items
you were sorting were coming from an _outside_ source, so it could be
subtracting when it wasn't actually needed, making the index too _small_.

This checks each element being sorted and only subtracts from the index if the
element is contained in the original container to begin with.

@mogstad I was going to add a test for this too but I kept encountering problem with the elements array being empty for the outside item and after spending awhile trying to figure out why I thought I'd  step back and open a pr without the test and see if you had any suggestions... The drop event dispatched correctly but `dragStart` never does so `@_elements` is `[]` instead of `[<outside item element>]`
