### PR TITLE
Remove cursorInsideElement check for draggable

### DIFF
--- a/demos/draggable.html
+++ b/demos/draggable.html
@@ -12,16 +12,21 @@
         width: 150px;
         height: 150px;
         background: green;
+        padding: 20px;
       }
       .droppable.hover {
         background: blue;
+      }
+
+      .droppable.hover * {
+        pointer-events: none;
       }
 
     </style>
   </head>
   <body>
     <div draggable="true"></div>
-    <div class="droppable"></div>
+    <div class="droppable"><div style="background: orange; width: 40px; height: 40px"></div></div>
 
     <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="http://localhost:4200/droppable.js"></script>

--- a/src/droppable.coffee
+++ b/src/droppable.coffee
@@ -1,7 +1,6 @@
 DragAndDrop = require "./common"
 
 config = require "./utilities/config"
-cursorInsideElement = require "./utilities/cursor_inside_element"
 dataFromEvent = require "./utilities/data_from_event"
 defaults = require "./utilities/defaults"
 normalizeEventCallback = require "./utilities/normalize_event_callback"
@@ -44,6 +43,7 @@ class Droppable extends DragAndDrop
   _handleDragenter: normalizeEventCallback (e, dataTransfer) ->
     if @_shouldAccept(e, dataTransfer)
       e.stopPropagation()
+      @_cleanUp()
       $(e.currentTarget).addClass(@options.hoverClass) if @options.hoverClass
       @options.over?(e, e.currentTarget, typesForDataTransfer(dataTransfer))
       unless @isBound
@@ -67,18 +67,11 @@ class Droppable extends DragAndDrop
     @_cleanUp()
 
   _handleDragleave: normalizeEventCallback (e, dataTransfer) ->
-    # HACK some UA fires drag leave too often, we need to make sure it’s
-    # actually outside of the element. There is probably better ways to check
-    # this as it’s covering every case.
-    if cursorInsideElement(e.originalEvent, e.currentTarget)
-      $(e.currentTarget).removeClass(@options.hoverClass) if @options.hoverClass
-      @options.out?(e, e.currentTarget, typesForDataTransfer(dataTransfer))
-
-    if cursorInsideElement(e.originalEvent, @el)
-      @_cleanUp()
-
+    $(e.currentTarget).removeClass(@options.hoverClass) if @options.hoverClass
+    @options.out?(e, e.currentTarget, typesForDataTransfer(dataTransfer))
+    @_cleanUp()
     e.stopPropagation()
-    e.preventDefault() # Figure out if this is needed
+    e.preventDefault()
 
   _handleDragover: normalizeEventCallback (e) ->
     @options.dragOver?(e, e.currentTarget)

--- a/tests/droppable.coffee
+++ b/tests/droppable.coffee
@@ -91,26 +91,6 @@ describe "Droppable", ->
         dispatchDragEvent(@el, "drop")
         expect(@options.drop).not.toHaveBeenCalled()
 
-    describe "not legit `dragleave`", ->
-      beforeEach ->
-        dispatchDragEvent(@el, "dragenter")
-        {@defaultPrevented} = dispatchDragEvent(@el, "dragleave", {
-          clientX: 300
-          clientY: 300
-          screenX: 300
-          screenY: 300
-        })
-
-      it "doesn’t call `options.out` if it’s still over it", ->
-        expect(@options.out).not.toHaveBeenCalled()
-
-      it "prevents default", ->
-        expect(@defaultPrevented).toBeTruthy()
-
-      it "keeps going on", ->
-        dispatchDragEvent(@el, "drop")
-        expect(@options.drop).toHaveBeenCalled()
-
   describe "`options.drop`", ->
     set "options", -> {drop: jasmine.createSpy("drop")}
     beforeEach ->


### PR DESCRIPTION
This was in place to hack around dragLeave events firing if a droppable element had children. When a user would drag-leave out of a child element, a drag leave would fire on the parent and cause problems.

However, checking the bounds of the window and calculating whether someone dragged out of the droppable area was not entirely accurate either, because if a browser window was in the background and a small window was over top, a user could "leave" into the small on-top window and trick the calculation into thinking that the drag leave didn't happen.

Using pointer-events: none on all nested children also solves the drag leave firing problem, and doesn't the window-on-top bug either.

https://app.bananastand.org/teams/52/workspaces/1/tasks/5648726
