### PR TITLE
Check pointer events attribute on drag leave target before handling it

### DIFF
--- a/src/droppable.coffee
+++ b/src/droppable.coffee
@@ -67,11 +67,12 @@ class Droppable extends DragAndDrop
     @_cleanUp()
 
   _handleDragleave: normalizeEventCallback (e, dataTransfer) ->
-    $(e.currentTarget).removeClass(@options.hoverClass) if @options.hoverClass
-    @options.out?(e, e.currentTarget, typesForDataTransfer(dataTransfer))
-    @_cleanUp()
-    e.stopPropagation()
-    e.preventDefault()
+    if window.getComputedStyle(e.target)["pointer-events"] != "none"
+      $(e.currentTarget).removeClass(@options.hoverClass) if @options.hoverClass
+      @options.out?(e, e.currentTarget, typesForDataTransfer(dataTransfer))
+      @_cleanUp()
+      e.stopPropagation()
+      e.preventDefault()
 
   _handleDragover: normalizeEventCallback (e) ->
     @options.dragOver?(e, e.currentTarget)


### PR DESCRIPTION
It is possible for a dragLeave event to fire from a child element before the hover class was added on dragEventer and the pointer-events: none style applied.

By the time the event is looked at by droppable js, however, pointer-events: none will had had time to be applied, so we check to make sure the target has pointer-events enabled before cleaning up on dragLeave.
