### PR TITLE
Window mouseout

### DIFF
--- a/demos/draggable.html
+++ b/demos/draggable.html
@@ -12,21 +12,16 @@
         width: 150px;
         height: 150px;
         background: green;
-        padding: 20px;
       }
       .droppable.hover {
         background: blue;
-      }
-
-      .droppable.hover * {
-        pointer-events: none;
       }
 
     </style>
   </head>
   <body>
     <div draggable="true"></div>
-    <div class="droppable"><div style="background: orange; width: 40px; height: 40px"></div></div>
+    <div class="droppable"></div>
 
     <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="http://localhost:4200/droppable.js"></script>

--- a/src/droppable.coffee
+++ b/src/droppable.coffee
@@ -37,6 +37,7 @@ class Droppable extends DragAndDrop
   _cleanUp: ->
     @$el.off "drop", @options.selector, @_handleDrop
     @$el.off "dragleave", @options.selector, @_handleDragleave
+    $(window).off "mouseout", @_handleWindowMouseout
     @$el.off "dragover", @options.selector, @_handleDragover
     @isBound = false
 
@@ -49,6 +50,7 @@ class Droppable extends DragAndDrop
       unless @isBound
         @$el.on "drop", @options.selector, $.proxy(this, "_handleDrop")
         @$el.on "dragleave", @options.selector, $.proxy(this, "_handleDragleave")
+        $(window).on "mouseout", $.proxy(this, "_handleWindowMouseout")
         @$el.on "dragover", @options.selector, $.proxy(this, "_handleDragover")
         @isBound = true
 
@@ -64,6 +66,11 @@ class Droppable extends DragAndDrop
     # TODO remove, Flow specific behaviour
     $(document.body).trigger("drag:end", e)
 
+    @_cleanUp()
+
+  _handleWindowMouseout: normalizeEventCallback (e, dataTransfer) ->
+    $(@el).removeClass(@options.hoverClass) if @options.hoverClass
+    @options.out?(e, @el, typesForDataTransfer(dataTransfer))
     @_cleanUp()
 
   _handleDragleave: normalizeEventCallback (e, dataTransfer) ->

--- a/src/droppable.coffee
+++ b/src/droppable.coffee
@@ -1,6 +1,7 @@
 DragAndDrop = require "./common"
 
 config = require "./utilities/config"
+cursorInsideElement = require "./utilities/cursor_inside_element"
 dataFromEvent = require "./utilities/data_from_event"
 defaults = require "./utilities/defaults"
 normalizeEventCallback = require "./utilities/normalize_event_callback"
@@ -44,7 +45,6 @@ class Droppable extends DragAndDrop
   _handleDragenter: normalizeEventCallback (e, dataTransfer) ->
     if @_shouldAccept(e, dataTransfer)
       e.stopPropagation()
-      @_cleanUp()
       $(e.currentTarget).addClass(@options.hoverClass) if @options.hoverClass
       @options.over?(e, e.currentTarget, typesForDataTransfer(dataTransfer))
       unless @isBound
@@ -74,12 +74,18 @@ class Droppable extends DragAndDrop
     @_cleanUp()
 
   _handleDragleave: normalizeEventCallback (e, dataTransfer) ->
-    if window.getComputedStyle(e.target)["pointer-events"] != "none"
+    # HACK some UA fires drag leave too often, we need to make sure it’s
+    # actually outside of the element. There is probably better ways to check
+    # this as it’s covering every case.
+    if cursorInsideElement(e.originalEvent, e.currentTarget)
       $(e.currentTarget).removeClass(@options.hoverClass) if @options.hoverClass
       @options.out?(e, e.currentTarget, typesForDataTransfer(dataTransfer))
+
+    if cursorInsideElement(e.originalEvent, @el)
       @_cleanUp()
-      e.stopPropagation()
-      e.preventDefault()
+
+    e.stopPropagation()
+    e.preventDefault() # Figure out if this is needed
 
   _handleDragover: normalizeEventCallback (e) ->
     @options.dragOver?(e, e.currentTarget)

--- a/tests/droppable.coffee
+++ b/tests/droppable.coffee
@@ -91,6 +91,26 @@ describe "Droppable", ->
         dispatchDragEvent(@el, "drop")
         expect(@options.drop).not.toHaveBeenCalled()
 
+    describe "not legit `dragleave`", ->
+      beforeEach ->
+        dispatchDragEvent(@el, "dragenter")
+        {@defaultPrevented} = dispatchDragEvent(@el, "dragleave", {
+          clientX: 300
+          clientY: 300
+          screenX: 300
+          screenY: 300
+        })
+
+      it "doesn’t call `options.out` if it’s still over it", ->
+        expect(@options.out).not.toHaveBeenCalled()
+
+      it "prevents default", ->
+        expect(@defaultPrevented).toBeTruthy()
+
+      it "keeps going on", ->
+        dispatchDragEvent(@el, "drop")
+        expect(@options.drop).toHaveBeenCalled()
+
   describe "`options.drop`", ->
     set "options", -> {drop: jasmine.createSpy("drop")}
     beforeEach ->


### PR DESCRIPTION
I may have to admit defeat here @mogstad  as much as I don't want to. I still love the pointer-events fix in theory!

The issue you pointed out in the sidebar with stuck drag-enter states is because as we "leave" the element, it removes the dragover class and this immediately fires a drag-enter, even though we have technically already left.

And since we have already left, another drag leave is never fired, so we get stuck with elements in permanent drag-enter states.  :neutral_face: 
