### PR TITLE
Update Sortable handleDrop to pass dropped section element to callback

### DIFF
--- a/src/sortable.coffee
+++ b/src/sortable.coffee
@@ -63,6 +63,7 @@ class Sortable extends DragAndDrop
         $elements.detach()
 
       $placeholder = $(@placeholder)
+      _droppedElement = $placeholder.parent()[0]
       _index = $placeholder.index()
 
       # If @options.manual is true we didn't detach original elements,
@@ -85,7 +86,7 @@ class Sortable extends DragAndDrop
 
       $placeholder.detach()
 
-      @options.sort?.call(this, _index, data, @_elements)
+      @options.sort?.call(this, _index, data, @_elements, _droppedElement)
       @options.stop?.call(this, @_elements)
 
   _handleDragend: normalizeEventCallback (e) ->


### PR DESCRIPTION
This is used to determine the dropped area when there are multiple sortable sections nested within another (eg. A list of subtasks nested in a list of regular Tasks).