### PR TITLE
Update Sortable handleDrop to pass indexAdjusted bool to callback

### DIFF
--- a/src/sortable.coffee
+++ b/src/sortable.coffee
@@ -72,6 +72,7 @@ class Sortable extends DragAndDrop
       if @options.manual && _index > data.originalIndex.start
         for element in $elements when @el.contains(element)
           _index -= 1
+          _indexAdjusted = true
 
       # If were moving the elements "up", then the placeholder would be above where the
       # elements came from, so we'll need to -1 from the originalIndex indices.
@@ -86,7 +87,7 @@ class Sortable extends DragAndDrop
 
       $placeholder.detach()
 
-      @options.sort?.call(this, _index, data, @_elements, _droppedElement)
+      @options.sort?.call(this, _index, data, @_elements, _droppedElement, _indexAdjusted)
       @options.stop?.call(this, @_elements)
 
   _handleDragend: normalizeEventCallback (e) ->


### PR DESCRIPTION
This is to let the callback know if the placeholder index has been adjusted by -= 1, and so it may be re-adjusted if necessary.

The index would need to be re-adjusted if a view has multiple sortable sections nested within each other and the original element is from the same section as the placeholder - in this case the placeholder index is unaffected by the original element position and therefore does not need to remain adjusted by -= 1.