### PR TITLE
Tweak sortable to avoid issue with certain drops 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "droppable.js",
-  "version": "2.0.12",
+  "version": "2.0.14",
   "description": "",
   "main": "dist/droppable.js",
   "scripts": {


### PR DESCRIPTION
If sortable was initiated on element X which contained some non
sortable items (like a header or a footer), you could encounter certain
situations where the placeholder was shown correctly but nothing
registered upon drop. This was because all the events were attached in
a way which filtered on the @options.items selector, so the drop
event didn’t work if the drop event occurred when the mouse was over
the header or the footer. Instead all events are bound to the top
level element without a selector filter, and a few checks are added
where necessary.

https://next.bananastand.org/organizations/52/teams/1/tasks/5707762
https://app.bananastand.org/organizations/52/teams/1/tasks/5700051



Previous: https://github.com/flowapp/droppable.js/pull/18